### PR TITLE
Update the difi dependency to 8.1.0

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,31 @@
+name: DIFI branch CI pipeline
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+              python-version: "3.13"
+
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install -e .
+
+        - name: System Test
+          run: |
+            python tests/validate_above_sq_current.py
+            python tests/validate_CM6.py
+

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,34 @@
+name: DIFI Pull Request CI pipeline
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+    test:
+        runs-on: ubuntu-latetest
+        strategy:
+            fail-fast: true
+            matrix:
+                python_version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+
+        steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+
+        - name: Set up Python
+          uses: actions/setup-python@v5
+          with:
+              python-version: ${{ matrix.python_version }}
+
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+            pip install -e .
+
+        - name: System Test
+          run: |
+            python tests/validate_CM6.py
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = ["numpy",
     "geomaglib>=1.2.1",
-    "pydifi @ https://github.com/CIRES-Geomagnetism/DIFI/releases/download/v8.0.2/pydifi-8.0.0-py3-none-any.whl",
+    "pydifi @ https://github.com/CIRES-Geomagnetism/DIFI/releases/download/v8.1.0/pydifi-8.1.0-py3-none-any.whl",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py_CM6"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
     { name="Collin Kadlecek", email="Collin.Kadlecek@colorado.edu" },
     { name="Li-Yin Young", email="liyin.young@colorado.edu" },

--- a/tests/validate_above_sq_current.py
+++ b/tests/validate_above_sq_current.py
@@ -1,5 +1,5 @@
 import numpy as np
-from CM6.CM6.getSQfield_CM6 import getSQfield
+from CM6.getSQfield_CM6 import getSQfield_CM6
 def parse_sq_input_output(filepath):
     import re
     import numpy as np
@@ -39,7 +39,7 @@ def parse_sq_input_output(filepath):
 inputs = parse_sq_input_output('tests/test_val_above_SQ.txt')
 # print("inptuts", inputs)
 inputs['theta_1'] = 90 - np.array(inputs['theta_1'])
-B = getSQfield(inputs['theta_1'], inputs['phi_1'], year = 2014, month = 3, day = 21, hour = 12, h = inputs['r_1']-6371.2,f107_1 = inputs['f107_1'], model_name = 'difi8', geoc = True )
+B = getSQfield_CM6(inputs['theta_1'], inputs['phi_1'], year = 2014, month = 3, day = 21, hour = 12, h = inputs['r_1']-6371.2,f107_1 = inputs['f107_1'], model_name = 'cm6', geoc = True )
 Bx = -B['X']
 By = B['Y']
 Bz = -B['Z']

--- a/tests/validate_list_input.py
+++ b/tests/validate_list_input.py
@@ -1,5 +1,5 @@
 import numpy as np
-from CM6.CM6.getSQfield_CM6 import getSQfield
+from CM6.getSQfield_CM6 import getSQfield_CM6
 
 def parse_geomagnetic_data(filepath):
     # Define column labels
@@ -20,9 +20,9 @@ def parse_geomagnetic_data(filepath):
     
     return data
 
-models = ['xDIFI2', 'DIFI8']
+models = ['CM6']
 for model_name in models:
-    data = parse_geomagnetic_data(f"tests/test_values_{model_name}_v1_20250528.txt")
+    data = parse_geomagnetic_data(f"tests/test_values_{model_name}_v1_20250731.txt")
     lat, lon, year, month, day, hour, minute, h, f107 = [],[],[],[],[],[],[],[],[]
     for i in range(0,len(data)):
         lat.append(data[i]['lat'])
@@ -36,7 +36,7 @@ for model_name in models:
         f107.append(data[i]['F10.7'])
 
 
-    B = getSQfield(lat, lon, year, 
+    B = getSQfield_CM6(lat, lon, year,
                     month, day, hour=hour,
                         minutes = minute, h = h,f107_1 = f107, 
                         model_name = model_name)

--- a/tests/validate_sqlfield_geoc.py
+++ b/tests/validate_sqlfield_geoc.py
@@ -1,5 +1,5 @@
 import numpy as np
-from CM6.CM6.getSQfield_CM6 import getSQfield
+from CM6.getSQfield_CM6 import getSQfield_CM6
 
 def parse_geomagnetic_data(filepath):
     # Define column labels
@@ -30,7 +30,7 @@ max_diff = 0.0
 
 for i in range(0, len(data)):
 
-    B = getSQfield(data[i]['theta'],  data[i]['lon'], data[i]['year'], data[i]['month'], data[i]['day'], hour=data[i]['hour'], minutes = data[i]['min'], r = data[i]['r'],f107_1 = data[i]['F10.7'], geoc = True, model_name='difi8')
+    B = getSQfield_CM6(data[i]['theta'],  data[i]['lon'], data[i]['year'], data[i]['month'], data[i]['day'], hour=data[i]['hour'], minutes = data[i]['min'], r = data[i]['r'],f107_1 = data[i]['F10.7'], geoc = True, model_name='cm6')
     if B['X'] != data[i]['X']:
          max_diff = max(max_diff, np.abs(B['X'] - data[i]['X']))
     if B['Y'] != data[i]['Y']:

--- a/tests/validate_time_range_list.py
+++ b/tests/validate_time_range_list.py
@@ -1,5 +1,5 @@
 import numpy as np
-from CM6.CM6.getSQfield_CM6 import getSQfield
+from CM6.getSQfield_CM6 import getSQfield_CM6
 
 
 def parse_geomagnetic_data(filepath):
@@ -24,7 +24,7 @@ def parse_geomagnetic_data(filepath):
 if __name__ == '__main__':
     #list input, double wanrning for values being above and below tolerance
     model_name = 'CM6'
-    data = parse_geomagnetic_data(f"tests/test_values_{model_name}_v1_20250528.txt")
+    data = parse_geomagnetic_data(f"tests/test_values_{model_name}_v1_20250731.txt")
     lat, lon, year, month, day, hour, minute, h, f107 = [],[],[],[],[],[],[],[],[]
     for i in range(0,len(data)):
         lat.append(data[i]['lat'])
@@ -45,13 +45,13 @@ if __name__ == '__main__':
     hours = np.linspace(0,23, N)
     minutes = np.linspace(0,59, N)
 
-    B = getSQfield(lat, lon,years, 
+    B = getSQfield_CM6(lat, lon,years,
                     months, days, hour= hours, minutes=minutes ,
                     h = 0,f107_1 = 100, 
-                    model_name = 'xdifi2')
+                    model_name = 'cm6')
     
     years = np.linspace(2014, 2024, N)
-    B = getSQfield(lat, lon,years, 
+    B = getSQfield_CM6(lat, lon,years,
                     months, days, hour= hours, minutes=minutes ,
                     h = 0,f107_1 = 100, 
-                    model_name = 'difi8')
+                    model_name = 'cm6')

--- a/tests/validate_time_range_list_no_warning.py
+++ b/tests/validate_time_range_list_no_warning.py
@@ -1,5 +1,5 @@
 import numpy as np
-from CM6.CM6.getSQfield_CM6 import getSQfield
+from CM6.getSQfield_CM6 import getSQfield_CM6
 
 def parse_geomagnetic_data(filepath):
     # Define column labels
@@ -44,14 +44,14 @@ if __name__ == '__main__':
     hours = np.linspace(0,23, N)
     minutes = np.linspace(0,59, N)
 
-    B = getSQfield(lat, lon,years, 
+    B = getSQfield_CM6(lat, lon,years,
                     months, days, hour= hours, minutes=minutes ,
                     h = 0,f107_1 = 100, 
-                    model_name = 'xdifi2')
+                    model_name = 'cm6')
     
     years = np.linspace(2014, 2023, N)
-    B = getSQfield(lat, lon,years, 
+    B = getSQfield_CM6(lat, lon,years,
                     months, days, hour= hours, minutes=minutes ,
                     h = 0,f107_1 = 100, 
-                    model_name = 'difi8')
+                    model_name = 'cm6')
     print("no warnings should print")

--- a/tests/validate_time_range_point.py
+++ b/tests/validate_time_range_point.py
@@ -1,5 +1,5 @@
 import numpy as np
-from CM6.CM6.getSQfield_CM6 import getSQfield
+from CM6.getSQfield_CM6 import getSQfield_CM6
 
 def parse_geomagnetic_data(filepath):
     # Define column labels
@@ -21,22 +21,22 @@ def parse_geomagnetic_data(filepath):
     return data
 def test_single_time_points():
     #early warning: input date is just before the minimum recomended time
-    B = getSQfield(0, 0, 2000, 
+    B = getSQfield_CM6(0, 0, 2000,
                     1, 1, h = 0,f107_1 = 100, 
-                        model_name = 'xdifi2')
+                        model_name = 'cm6')
 
     #late warning: input date is just after the maximum recomended time
-    B = getSQfield(0, 0, 2024, 
+    B = getSQfield_CM6(0, 0, 2024,
                     1, 2, h = 0,f107_1 = 100, 
-                        model_name = 'xdifi2')
+                        model_name = 'cm6')
     #early warning: input date is just before the minimum recomended time
-    B = getSQfield(0, 0, 2000, 
+    B = getSQfield_CM6(0, 0, 2000,
                     1, 1, h = 0,f107_1 = 100, 
-                        model_name = 'difi8')
+                        model_name = 'cm6')
     #late warning: input date is just after the maximum recomended time
-    B = getSQfield(0, 0, 2024, 
+    B = getSQfield_CM6(0, 0, 2024,
                     1, 2, h = 0,f107_1 = 100, 
-                        model_name = 'difi8')
+                        model_name = 'cm6')
 
 if __name__ == '__main__':
     """Should print 4 warnings, for out of time range"""


### PR DESCRIPTION
Update the difi Python API from 8.0.0 to 8.1.0. 

- The max difference against CM6 test values is 5.67796176e-07. The results is generated by validate_CM6.py
- It passed the tests at validate_above_sq_current.py and validate_list_input.py
- Updated the version number from 1.0.1 to 1.0.2
- Fixed the command for importing getSQfield_CM6 at test files.
